### PR TITLE
feat: Add social sharing and enhanced dashboard stats

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,22 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="theme-color" content="#121212">
   <meta name="description" content="Discover how your Spotify saved tracks compare to global listening trends">
+
+  <!-- Open Graph / Facebook -->
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://are-my-favourites-popular.vercel.app/">
+  <meta property="og:title" content="Are My Favourites Popular?">
+  <meta property="og:description" content="Discover how your Spotify saved tracks compare to global listening trends">
+  <meta property="og:image" content="https://are-my-favourites-popular.vercel.app/og-image.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Are My Favourites Popular?">
+  <meta name="twitter:description" content="Discover how your Spotify saved tracks compare to global listening trends">
+  <meta name="twitter:image" content="https://are-my-favourites-popular.vercel.app/og-image.png">
+
   <link rel="icon" type="image/svg+xml" href="/favicon.svg">
   <title>Are My Favourites Popular?</title>
 

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -14,7 +14,7 @@ import {
   setupDataPointHandlers,
   createTooltipContent,
 } from './chart';
-import type { DashboardProps, SavedTrack, SpotifyTrack } from '../types/spotify';
+import type { DashboardProps, SavedTrack, SpotifyArtist, SpotifyTrack } from '../types/spotify';
 import Footer from './Footer';
 import { ShareButtonGroup } from './sharing';
 import './dashboard.css';
@@ -24,8 +24,16 @@ interface ChartStats {
   total: number;
   avgPopularity: number;
   maxPopularity: number;
-  zeroCount: number;
-  topTrackId: string;
+  hipsterScore: number;
+  mainstreamScore: number;
+  hiddenGems: number;
+  deepCuts: number;
+  uniqueArtists: number;
+  uniqueGenres: number;
+  collectionAge: string;
+  topTrack: SpotifyTrack;
+  mostSavedArtist: SpotifyArtist | null;
+  mostPopularArtist: SpotifyArtist | null;
 }
 
 function Dashboard({ tracks, artistMap, onLogout, getAccessToken }: DashboardProps): ReactElement {
@@ -45,20 +53,99 @@ function Dashboard({ tracks, artistMap, onLogout, getAccessToken }: DashboardPro
     if (!tracks || tracks.length === 0) return null;
     const avgPop = mean(tracks, (d: SavedTrack) => d.track.popularity) ?? 0;
     const maxPop = max(tracks, (d: SavedTrack) => d.track.popularity) ?? 0;
-    const zeroCount = tracks.filter((d: SavedTrack) => d.track.popularity === 0).length;
     const topTrack = tracks.reduce(
       (best: SavedTrack, curr: SavedTrack) =>
         curr.track.popularity > best.track.popularity ? curr : best,
       tracks[0]
     );
+
+    // Hipster/Mainstream scores (% of tracks)
+    const hipsterCount = tracks.filter(
+      (d) => d.track.popularity > 0 && d.track.popularity < 30
+    ).length;
+    const mainstreamCount = tracks.filter((d) => d.track.popularity >= 70).length;
+    const hipsterScore = Math.round((hipsterCount / tracks.length) * 100);
+    const mainstreamScore = Math.round((mainstreamCount / tracks.length) * 100);
+
+    // Hidden gems (1-20 popularity) and deep cuts (0 popularity)
+    const hiddenGems = tracks.filter(
+      (d) => d.track.popularity > 0 && d.track.popularity <= 20
+    ).length;
+    const deepCuts = tracks.filter((d) => d.track.popularity === 0).length;
+
+    // Unique artists and genres, with popularity tracking
+    const artistIds = new Set<string>();
+    const genreSet = new Set<string>();
+    const artistStats = new Map<string, { count: number; totalPop: number }>();
+
+    tracks.forEach((t) => {
+      // Skip local tracks for popularity calculations (they always have 0)
+      const trackPop = t.track.is_local ? 0 : t.track.popularity;
+      const isLocalTrack = t.track.is_local;
+
+      t.track.artists.forEach((artist) => {
+        artistIds.add(artist.id);
+
+        // Track count and popularity per artist
+        const stats = artistStats.get(artist.id) ?? { count: 0, totalPop: 0 };
+        stats.count++;
+        if (!isLocalTrack) {
+          stats.totalPop += trackPop;
+        }
+        artistStats.set(artist.id, stats);
+
+        // Get genres from artistMap
+        const fullArtist = artistMap?.get(artist.id);
+        fullArtist?.genres?.forEach((genre) => genreSet.add(genre));
+      });
+    });
+
+    // Find most frequently saved artist
+    let mostSavedArtistId = '';
+    let maxCount = 0;
+    artistStats.forEach((stats, id) => {
+      if (stats.count > maxCount) {
+        maxCount = stats.count;
+        mostSavedArtistId = id;
+      }
+    });
+    const mostSavedArtist = artistMap?.get(mostSavedArtistId) ?? null;
+
+    // Find most popular artist (by Spotify artist popularity score)
+    let mostPopularArtist: SpotifyArtist | null = null;
+    let highestPopularity = -1;
+    artistIds.forEach((id) => {
+      const artist = artistMap?.get(id);
+      if (artist?.popularity !== undefined && artist.popularity > highestPopularity) {
+        highestPopularity = artist.popularity;
+        mostPopularArtist = artist;
+      }
+    });
+
+    // Collection age (time since first saved track) as decimal years
+    const dates = tracks.map((t) => new Date(t.added_at).getTime());
+    const oldestDate = new Date(Math.min(...dates));
+    const now = new Date();
+    const diffMs = now.getTime() - oldestDate.getTime();
+    const diffYears = diffMs / (1000 * 60 * 60 * 24 * 365.25);
+    const collectionAge = diffYears >= 1 ? diffYears.toFixed(1) : diffYears.toFixed(2);
+
     return {
       total: tracks.length,
       avgPopularity: Math.round(avgPop),
       maxPopularity: maxPop,
-      zeroCount,
-      topTrackId: topTrack.track.id,
+      hipsterScore,
+      mainstreamScore,
+      hiddenGems,
+      deepCuts,
+      uniqueArtists: artistIds.size,
+      uniqueGenres: genreSet.size,
+      collectionAge,
+      topTrack: topTrack.track,
+      mostSavedArtist,
+      mostPopularArtist,
     };
-  }, [tracks]);
+  }, [tracks, artistMap]);
 
   // Spotify Web Playback SDK
   const player = useSpotifyPlayer(getAccessToken);
@@ -183,22 +270,7 @@ function Dashboard({ tracks, artistMap, onLogout, getAccessToken }: DashboardPro
         <h1>
           Are My Favourites <span className="text-green">Popular?</span>
         </h1>
-        <p className="subtitle">
-          Popularity scores reflect current streaming activity, not when you added each track
-        </p>
         <p className="helper-text">Click any track to play it in the player below</p>
-        {chartStats && (
-          <div className="dashboard-share">
-            <ShareButtonGroup
-              stats={{
-                totalTracks: chartStats.total,
-                avgPopularity: chartStats.avgPopularity,
-              }}
-              variant="secondary"
-              showToggle={true}
-            />
-          </div>
-        )}
       </header>
 
       {tracks ? (
@@ -212,35 +284,123 @@ function Dashboard({ tracks, artistMap, onLogout, getAccessToken }: DashboardPro
             ></svg>
             <div ref={tooltipRef} className="tooltip"></div>
           </div>
-          <div className="chart-legend">
-            <div className="chart-legend-gradient"></div>
-            <div className="chart-legend-labels">
-              <span>High popularity</span>
-              <span>Low popularity</span>
+          <div className="chart-info">
+            <div className="chart-legend">
+              <div className="chart-legend-gradient"></div>
+              <div className="chart-legend-labels">
+                <span>High popularity</span>
+                <span>Low popularity</span>
+              </div>
+              <p className="chart-legend-note">
+                Based on your Liked Songs. Popularity reflects current streaming activity, not when
+                you saved each track.
+              </p>
             </div>
+            {chartStats && (
+              <>
+                <div className="chart-info-separator"></div>
+                <div className="chart-highlights">
+                  <a
+                    href={chartStats.topTrack.external_urls.spotify}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="chart-highlight"
+                  >
+                    <img
+                      src={
+                        chartStats.topTrack.album.images[1]?.url ??
+                        chartStats.topTrack.album.images[0]?.url
+                      }
+                      alt={chartStats.topTrack.album.name}
+                      className="chart-highlight__img"
+                    />
+                    <span className="chart-highlight__label">Top Track</span>
+                    <span className="chart-highlight__name">{chartStats.topTrack.name}</span>
+                  </a>
+                  {chartStats.mostSavedArtist?.images?.[0] && (
+                    <a
+                      href={chartStats.mostSavedArtist.external_urls.spotify}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="chart-highlight"
+                    >
+                      <img
+                        src={
+                          chartStats.mostSavedArtist.images[1]?.url ??
+                          chartStats.mostSavedArtist.images[0]?.url
+                        }
+                        alt={chartStats.mostSavedArtist.name}
+                        className="chart-highlight__img"
+                      />
+                      <span className="chart-highlight__label">Most Saved</span>
+                      <span className="chart-highlight__name">
+                        {chartStats.mostSavedArtist.name}
+                      </span>
+                    </a>
+                  )}
+                  {chartStats.mostPopularArtist?.images?.[0] && (
+                    <a
+                      href={chartStats.mostPopularArtist.external_urls.spotify}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="chart-highlight"
+                    >
+                      <img
+                        src={
+                          chartStats.mostPopularArtist.images[1]?.url ??
+                          chartStats.mostPopularArtist.images[0]?.url
+                        }
+                        alt={chartStats.mostPopularArtist.name}
+                        className="chart-highlight__img"
+                      />
+                      <span className="chart-highlight__label">Most Popular</span>
+                      <span className="chart-highlight__name">
+                        {chartStats.mostPopularArtist.name}
+                      </span>
+                    </a>
+                  )}
+                </div>
+                <div className="chart-info-separator"></div>
+                <div className="chart-stats">
+                  <div className="chart-stat">
+                    <span className="chart-stat-value">{chartStats.total.toLocaleString()}</span>
+                    <span className="chart-stat-label">Tracks</span>
+                  </div>
+                  <div className="chart-stat">
+                    <span className="chart-stat-value">{chartStats.uniqueArtists}</span>
+                    <span className="chart-stat-label">Artists</span>
+                  </div>
+                  <div className="chart-stat">
+                    <span className="chart-stat-value">{chartStats.uniqueGenres}</span>
+                    <span className="chart-stat-label">Genres</span>
+                  </div>
+                  <div className="chart-stat">
+                    <span className="chart-stat-value">{chartStats.collectionAge}</span>
+                    <span className="chart-stat-label">Years Collecting</span>
+                  </div>
+                </div>
+                <div className="chart-info-separator"></div>
+                <div className="chart-stats">
+                  <div className="chart-stat">
+                    <span className="chart-stat-value">{chartStats.hipsterScore}%</span>
+                    <span className="chart-stat-label">Hipster</span>
+                  </div>
+                  <div className="chart-stat">
+                    <span className="chart-stat-value">{chartStats.mainstreamScore}%</span>
+                    <span className="chart-stat-label">Mainstream</span>
+                  </div>
+                  <div className="chart-stat">
+                    <span className="chart-stat-value">{chartStats.hiddenGems}</span>
+                    <span className="chart-stat-label">Hidden Gems</span>
+                  </div>
+                  <div className="chart-stat">
+                    <span className="chart-stat-value">{chartStats.deepCuts}</span>
+                    <span className="chart-stat-label">Deep Cuts</span>
+                  </div>
+                </div>
+              </>
+            )}
           </div>
-          {chartStats && (
-            <div className="chart-stats">
-              <div className="chart-stat">
-                <span className="chart-stat-value">{chartStats.total.toLocaleString()}</span>
-                <span className="chart-stat-label">Total Tracks</span>
-              </div>
-              <div className="chart-stat">
-                <span className="chart-stat-value">{chartStats.avgPopularity}</span>
-                <span className="chart-stat-label">Avg Popularity</span>
-              </div>
-              <div className="chart-stat">
-                <span className="chart-stat-value chart-stat-value--highlight">
-                  {chartStats.maxPopularity}
-                </span>
-                <span className="chart-stat-label">Highest</span>
-              </div>
-              <div className="chart-stat">
-                <span className="chart-stat-value">{chartStats.zeroCount}</span>
-                <span className="chart-stat-label">Zero Popularity</span>
-              </div>
-            </div>
-          )}
         </div>
       ) : (
         <div className="loading">
@@ -265,6 +425,19 @@ function Dashboard({ tracks, artistMap, onLogout, getAccessToken }: DashboardPro
         onNext={player.nextTrack}
         onVolumeChange={player.setVolume}
       />
+
+      {chartStats && (
+        <div className="dashboard-share">
+          <ShareButtonGroup
+            stats={{
+              totalTracks: chartStats.total,
+              avgPopularity: chartStats.avgPopularity,
+            }}
+            variant="secondary"
+            showToggle={true}
+          />
+        </div>
+      )}
 
       {tracks && <Stats tracks={tracks} artistMap={artistMap} onPlayTrack={playTrack} />}
 

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -16,6 +16,7 @@ import {
 } from './chart';
 import type { DashboardProps, SavedTrack, SpotifyTrack } from '../types/spotify';
 import Footer from './Footer';
+import { ShareButtonGroup } from './sharing';
 import './dashboard.css';
 import './graph.css';
 
@@ -186,6 +187,18 @@ function Dashboard({ tracks, artistMap, onLogout, getAccessToken }: DashboardPro
           Popularity scores reflect current streaming activity, not when you added each track
         </p>
         <p className="helper-text">Click any track to play it in the player below</p>
+        {chartStats && (
+          <div className="dashboard-share">
+            <ShareButtonGroup
+              stats={{
+                totalTracks: chartStats.total,
+                avgPopularity: chartStats.avgPopularity,
+              }}
+              variant="secondary"
+              showToggle={true}
+            />
+          </div>
+        )}
       </header>
 
       {tracks ? (

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,4 +1,7 @@
 import type { ReactElement } from 'react';
+import { ShareButton } from './sharing';
+import type { SharePlatform } from '../types/sharing';
+import { getStaticShareContent } from '../utils/sharing';
 import './footer.css';
 
 interface FooterProps {
@@ -43,6 +46,18 @@ function Footer({ onLogout }: FooterProps): ReactElement {
         >
           GitHub
         </a>
+      </div>
+      <div className="footer-share">
+        <span className="footer-share__label">Share:</span>
+        {(['twitter', 'facebook', 'linkedin', 'copy'] as SharePlatform[]).map((platform) => (
+          <ShareButton
+            key={platform}
+            platform={platform}
+            content={getStaticShareContent()}
+            variant="icon-only"
+            size="sm"
+          />
+        ))}
       </div>
       <a
         href="https://www.spotify.com"

--- a/src/components/dashboard.css
+++ b/src/components/dashboard.css
@@ -31,13 +31,29 @@
   width: 100%;
 }
 
+/* Chart Info (legend + stats container) */
+.chart-info {
+  display: flex;
+  align-items: center;
+  gap: var(--space-lg);
+  padding: var(--space-md) 0;
+  margin-top: var(--space-sm);
+  border-top: 1px solid var(--border-subtle);
+}
+
+.chart-info-separator {
+  width: 1px;
+  align-self: stretch;
+  background: var(--border-subtle);
+}
+
 /* Chart Legend */
 .chart-legend {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
-  justify-content: center;
   gap: var(--space-sm);
-  padding: var(--space-sm) 0;
+  max-width: 180px;
 }
 
 .chart-legend-gradient {
@@ -56,14 +72,66 @@
   color: var(--text-secondary);
 }
 
+.chart-legend-note {
+  flex-basis: 100%;
+  font-size: var(--font-size-xs);
+  color: var(--text-muted);
+  margin: 0;
+  padding-top: var(--space-xs);
+}
+
+/* Chart Highlights (top track/artist thumbnails) */
+.chart-highlights {
+  display: flex;
+  gap: var(--space-md);
+}
+
+.chart-highlight {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-xs);
+  text-decoration: none;
+  transition: transform var(--transition-fast);
+}
+
+.chart-highlight:hover {
+  transform: scale(1.05);
+}
+
+.chart-highlight__img {
+  width: 64px;
+  height: 64px;
+  border-radius: var(--radius-sm);
+  object-fit: cover;
+}
+
+.chart-highlight__label {
+  font-size: 10px;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  text-align: center;
+}
+
+.chart-highlight__name {
+  font-size: var(--font-size-xs);
+  color: var(--text-primary);
+  max-width: 80px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  text-align: center;
+}
+
+.chart-highlight:hover .chart-highlight__name {
+  color: var(--spotify-green);
+}
+
 /* Chart Stats */
 .chart-stats {
   display: flex;
-  justify-content: center;
   gap: var(--space-xl);
-  padding: var(--space-md) 0;
-  border-top: 1px solid var(--border-subtle);
-  margin-top: var(--space-sm);
 }
 
 .chart-stat {
@@ -74,8 +142,8 @@
 }
 
 .chart-stat-value {
-  font-size: var(--font-size-lg);
-  font-weight: var(--font-weight-medium);
+  font-size: var(--font-size-xl);
+  font-weight: var(--font-weight-bold);
   color: var(--text-primary);
 }
 
@@ -88,6 +156,7 @@
   color: var(--text-muted);
   text-transform: uppercase;
   letter-spacing: 0.5px;
+  text-align: center;
 }
 
 /* Tooltip text-green utility */

--- a/src/components/sharing/ShareButton.tsx
+++ b/src/components/sharing/ShareButton.tsx
@@ -1,0 +1,112 @@
+import type { ReactElement } from 'react';
+import { useState, useCallback } from 'react';
+import type { ShareButtonProps, SharePlatform } from '../../types/sharing';
+import { getShareUrl, copyToClipboard, openSharePopup } from '../../utils/sharing';
+import './sharing.css';
+
+// Platform-specific icons as inline SVGs
+function XIcon(): ReactElement {
+  return (
+    <svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor" aria-hidden="true">
+      <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+    </svg>
+  );
+}
+
+function FacebookIcon(): ReactElement {
+  return (
+    <svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor" aria-hidden="true">
+      <path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z" />
+    </svg>
+  );
+}
+
+function LinkedInIcon(): ReactElement {
+  return (
+    <svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor" aria-hidden="true">
+      <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
+    </svg>
+  );
+}
+
+function LinkIcon(): ReactElement {
+  return (
+    <svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor" aria-hidden="true">
+      <path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z" />
+    </svg>
+  );
+}
+
+function CheckIcon(): ReactElement {
+  return (
+    <svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor" aria-hidden="true">
+      <path d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z" />
+    </svg>
+  );
+}
+
+const icons: Record<SharePlatform, () => ReactElement> = {
+  twitter: XIcon,
+  facebook: FacebookIcon,
+  linkedin: LinkedInIcon,
+  copy: LinkIcon,
+};
+
+const platformLabels: Record<SharePlatform, string> = {
+  twitter: 'Share on X',
+  facebook: 'Share on Facebook',
+  linkedin: 'Share on LinkedIn',
+  copy: 'Copy link',
+};
+
+function ShareButton({
+  platform,
+  content,
+  variant = 'secondary',
+  size = 'md',
+  onShare,
+}: ShareButtonProps): ReactElement {
+  const [copied, setCopied] = useState(false);
+
+  const handleClick = useCallback(async () => {
+    if (platform === 'copy') {
+      const success = await copyToClipboard(content.url);
+      if (success) {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      }
+    } else {
+      const shareUrl = getShareUrl(platform, content);
+      openSharePopup(shareUrl, platform);
+    }
+    onShare?.(platform);
+  }, [platform, content, onShare]);
+
+  const label = platform === 'copy' && copied ? 'Copied!' : platformLabels[platform];
+  const Icon = platform === 'copy' && copied ? CheckIcon : icons[platform];
+
+  const className = [
+    'share-btn',
+    `share-btn--${variant}`,
+    `share-btn--${size}`,
+    `share-btn--${platform}`,
+    copied && 'share-btn--success',
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <button
+      type="button"
+      className={className}
+      onClick={handleClick}
+      aria-label={label}
+      title={label}
+    >
+      <Icon />
+      {variant !== 'icon-only' && <span className="share-btn__label">{label}</span>}
+    </button>
+  );
+}
+
+export default ShareButton;

--- a/src/components/sharing/ShareButtonGroup.tsx
+++ b/src/components/sharing/ShareButtonGroup.tsx
@@ -1,0 +1,58 @@
+import type { ReactElement } from 'react';
+import { useState, useMemo } from 'react';
+import ShareButton from './ShareButton';
+import type { ShareButtonGroupProps, SharePlatform, ShareContent } from '../../types/sharing';
+import { getStaticShareContent, getPersonalizedShareContent } from '../../utils/sharing';
+import './sharing.css';
+
+const platforms: SharePlatform[] = ['twitter', 'facebook', 'linkedin', 'copy'];
+
+function ShareButtonGroup({
+  stats,
+  variant = 'secondary',
+  showToggle = true,
+  onShare,
+}: ShareButtonGroupProps): ReactElement {
+  const [usePersonalized, setUsePersonalized] = useState(!!stats);
+
+  const content: ShareContent = useMemo(() => {
+    if (usePersonalized && stats) {
+      return getPersonalizedShareContent(stats);
+    }
+    return getStaticShareContent();
+  }, [usePersonalized, stats]);
+
+  const handleShare = (platform: SharePlatform) => {
+    onShare?.(platform, usePersonalized);
+  };
+
+  return (
+    <div className="share-group">
+      {showToggle && stats && (
+        <div className="share-group__toggle">
+          <label className="share-toggle">
+            <input
+              type="checkbox"
+              checked={usePersonalized}
+              onChange={(e) => setUsePersonalized(e.target.checked)}
+            />
+            <span className="share-toggle__label">Share my stats</span>
+          </label>
+        </div>
+      )}
+      <div className="share-group__buttons">
+        {platforms.map((platform) => (
+          <ShareButton
+            key={platform}
+            platform={platform}
+            content={content}
+            variant={variant}
+            onShare={handleShare}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default ShareButtonGroup;

--- a/src/components/sharing/index.ts
+++ b/src/components/sharing/index.ts
@@ -1,0 +1,2 @@
+export { default as ShareButton } from './ShareButton';
+export { default as ShareButtonGroup } from './ShareButtonGroup';

--- a/src/components/sharing/sharing.css
+++ b/src/components/sharing/sharing.css
@@ -1,0 +1,248 @@
+/* Share Button Base */
+.share-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-sm);
+  font-family: var(--font-family);
+  font-weight: var(--font-weight-bold);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  border: none;
+  border-radius: var(--radius-pill);
+  cursor: pointer;
+  transition: all var(--transition-normal);
+  white-space: nowrap;
+}
+
+.share-btn:hover {
+  transform: scale(1.04);
+}
+
+.share-btn:active {
+  transform: scale(0.98);
+}
+
+.share-btn:focus-visible {
+  outline: 2px solid var(--spotify-green);
+  outline-offset: 2px;
+}
+
+/* Size Variants */
+.share-btn--sm {
+  padding: var(--space-xs) var(--space-sm);
+  font-size: var(--font-size-xs);
+}
+
+.share-btn--sm svg {
+  width: 14px;
+  height: 14px;
+}
+
+.share-btn--md {
+  padding: var(--space-sm) var(--space-md);
+  font-size: var(--font-size-sm);
+}
+
+.share-btn--lg {
+  padding: var(--space-md) var(--space-lg);
+  font-size: var(--font-size-base);
+}
+
+.share-btn--lg svg {
+  width: 20px;
+  height: 20px;
+}
+
+/* Style Variants */
+.share-btn--primary {
+  background: var(--spotify-green);
+  color: var(--spotify-black);
+}
+
+.share-btn--primary:hover {
+  background: var(--spotify-green-light);
+}
+
+.share-btn--secondary {
+  background: transparent;
+  color: var(--text-primary);
+  border: 1px solid var(--border-default);
+}
+
+.share-btn--secondary:hover {
+  border-color: var(--text-primary);
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.share-btn--icon-only {
+  background: transparent;
+  color: var(--text-secondary);
+  padding: var(--space-sm);
+  border-radius: 50%;
+}
+
+.share-btn--icon-only:hover {
+  color: var(--text-primary);
+  background: var(--surface-highlight);
+}
+
+.share-btn--icon-only .share-btn__label {
+  display: none;
+}
+
+/* Platform-specific hover colors */
+.share-btn--secondary.share-btn--twitter:hover {
+  border-color: #1da1f2;
+  color: #1da1f2;
+}
+
+.share-btn--secondary.share-btn--facebook:hover {
+  border-color: #1877f2;
+  color: #1877f2;
+}
+
+.share-btn--secondary.share-btn--linkedin:hover {
+  border-color: #0a66c2;
+  color: #0a66c2;
+}
+
+.share-btn--icon-only.share-btn--twitter:hover {
+  color: #1da1f2;
+}
+
+.share-btn--icon-only.share-btn--facebook:hover {
+  color: #1877f2;
+}
+
+.share-btn--icon-only.share-btn--linkedin:hover {
+  color: #0a66c2;
+}
+
+/* Success state for copy button */
+.share-btn--success {
+  border-color: var(--spotify-green) !important;
+  color: var(--spotify-green) !important;
+}
+
+/* Share Group */
+.share-group {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-md);
+}
+
+.share-group__buttons {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: var(--space-sm);
+}
+
+.share-group__toggle {
+  display: flex;
+  align-items: center;
+}
+
+/* Toggle Switch */
+.share-toggle {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  cursor: pointer;
+  color: var(--text-secondary);
+  font-size: var(--font-size-sm);
+}
+
+.share-toggle input {
+  appearance: none;
+  width: 36px;
+  height: 20px;
+  background: var(--surface-highlight);
+  border-radius: 10px;
+  position: relative;
+  cursor: pointer;
+  transition: background var(--transition-fast);
+}
+
+.share-toggle input::before {
+  content: '';
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 16px;
+  height: 16px;
+  background: var(--text-secondary);
+  border-radius: 50%;
+  transition:
+    transform var(--transition-fast),
+    background var(--transition-fast);
+}
+
+.share-toggle input:checked {
+  background: var(--spotify-green);
+}
+
+.share-toggle input:checked::before {
+  transform: translateX(16px);
+  background: var(--spotify-black);
+}
+
+.share-toggle input:focus-visible {
+  outline: 2px solid var(--spotify-green);
+  outline-offset: 2px;
+}
+
+/* Footer Share Section */
+.footer-share {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+}
+
+.footer-share__label {
+  font-size: var(--font-size-sm);
+  color: var(--text-muted);
+}
+
+/* Dashboard Header Share Section */
+.dashboard-share {
+  display: flex;
+  justify-content: center;
+  margin-top: var(--space-lg);
+}
+
+/* Responsive */
+@media (max-width: 600px) {
+  .share-group__buttons {
+    justify-content: center;
+  }
+
+  .share-btn--md .share-btn__label,
+  .share-btn--sm .share-btn__label {
+    display: none;
+  }
+
+  .share-btn--md,
+  .share-btn--sm {
+    padding: var(--space-sm);
+    border-radius: 50%;
+  }
+}
+
+/* Reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .share-btn {
+    transition: none;
+  }
+
+  .share-btn:hover {
+    transform: none;
+  }
+
+  .share-toggle input,
+  .share-toggle input::before {
+    transition: none;
+  }
+}

--- a/src/types/sharing.ts
+++ b/src/types/sharing.ts
@@ -1,0 +1,28 @@
+export type SharePlatform = 'twitter' | 'facebook' | 'linkedin' | 'copy';
+
+export interface ShareContent {
+  url: string;
+  title: string;
+  text: string;
+  hashtags?: string[];
+}
+
+export interface PersonalizedStats {
+  totalTracks: number;
+  avgPopularity: number;
+}
+
+export interface ShareButtonProps {
+  platform: SharePlatform;
+  content: ShareContent;
+  variant?: 'primary' | 'secondary' | 'icon-only';
+  size?: 'sm' | 'md' | 'lg';
+  onShare?: (platform: SharePlatform) => void;
+}
+
+export interface ShareButtonGroupProps {
+  stats?: PersonalizedStats | null;
+  variant?: 'primary' | 'secondary' | 'icon-only';
+  showToggle?: boolean;
+  onShare?: (platform: SharePlatform, isPersonalized: boolean) => void;
+}

--- a/src/utils/sharing.ts
+++ b/src/utils/sharing.ts
@@ -1,0 +1,92 @@
+import type { ShareContent, SharePlatform, PersonalizedStats } from '../types/sharing';
+
+/** Base URL for the app */
+export const APP_URL = typeof window !== 'undefined' ? window.location.origin : '';
+
+/** Generate static share content (generic app promotion) */
+export function getStaticShareContent(): ShareContent {
+  return {
+    url: APP_URL,
+    title: 'Are My Favourites Popular?',
+    text: 'Discover how your Spotify saved tracks compare to global listening trends!',
+    hashtags: ['Spotify', 'Music', 'DataViz'],
+  };
+}
+
+/** Generate personalized share content based on user stats */
+export function getPersonalizedShareContent(stats: PersonalizedStats): ShareContent {
+  const { totalTracks, avgPopularity } = stats;
+
+  return {
+    url: APP_URL,
+    title: 'My Spotify Stats',
+    text: `I have ${totalTracks.toLocaleString()} saved tracks with an average popularity of ${Math.round(avgPopularity)}! Check yours:`,
+    hashtags: ['Spotify', 'MyMusicStats'],
+  };
+}
+
+/** Generate platform-specific share URL */
+export function getShareUrl(platform: SharePlatform, content: ShareContent): string {
+  const { url, title, text, hashtags } = content;
+  const encodedUrl = encodeURIComponent(url);
+  const encodedText = encodeURIComponent(text);
+  const encodedTitle = encodeURIComponent(title);
+
+  switch (platform) {
+    case 'twitter': {
+      const hashtagString = hashtags?.length ? `&hashtags=${hashtags.join(',')}` : '';
+      return `https://twitter.com/intent/tweet?url=${encodedUrl}&text=${encodedText}${hashtagString}`;
+    }
+
+    case 'facebook':
+      // Facebook only uses the URL, extracts OG tags
+      return `https://www.facebook.com/sharer/sharer.php?u=${encodedUrl}`;
+
+    case 'linkedin':
+      return `https://www.linkedin.com/shareArticle?mini=true&url=${encodedUrl}&title=${encodedTitle}&summary=${encodedText}`;
+
+    case 'copy':
+      return url; // Just return the URL for copying
+
+    default:
+      return url;
+  }
+}
+
+/** Copy text to clipboard */
+export async function copyToClipboard(text: string): Promise<boolean> {
+  try {
+    await navigator.clipboard.writeText(text);
+    return true;
+  } catch {
+    // Fallback for older browsers
+    const textarea = document.createElement('textarea');
+    textarea.value = text;
+    textarea.style.position = 'fixed';
+    textarea.style.opacity = '0';
+    document.body.appendChild(textarea);
+    textarea.select();
+    try {
+      document.execCommand('copy');
+      return true;
+    } catch {
+      return false;
+    } finally {
+      document.body.removeChild(textarea);
+    }
+  }
+}
+
+/** Open share URL in popup window */
+export function openSharePopup(url: string, platform: SharePlatform): void {
+  const width = 600;
+  const height = 400;
+  const left = (window.innerWidth - width) / 2;
+  const top = (window.innerHeight - height) / 2;
+
+  window.open(
+    url,
+    `share-${platform}`,
+    `width=${width},height=${height},left=${left},top=${top},toolbar=no,menubar=no`
+  );
+}


### PR DESCRIPTION
## Summary
- Add social sharing buttons (X, Facebook, LinkedIn, Copy Link) in dashboard and footer
- Reorganize chart info layout with legend, thumbnails, and enhanced stats
- Add thumbnails for Top Track, Most Saved Artist, and Most Popular Artist
- Add new stats: hipster/mainstream scores, hidden gems, deep cuts, unique artists/genres, years collecting
- Use Spotify's artist popularity score for artist rankings
- Weight genre popularity by track count
- Clarify app uses Liked Songs (not full library)
- Filter local files from popularity calculations

## Test plan
- [x] Build passes
- [x] Lint passes
- [x] Tests pass (104 tests)
- [ ] Verify share buttons work on each platform
- [ ] Verify OG meta tags render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)